### PR TITLE
feat: add index and feed scripts

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -1,0 +1,39 @@
+name: Generate Index
+
+on:
+  push:
+    paths:
+      - "stacks/**"
+      - "pkgmanagers/**"
+  workflow_dispatch:
+
+jobs:
+  combine:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Combine Stacks and Package Managers
+        run: deno run -RW scripts/combine.ts
+
+      - name: Create Atom Feed
+        run: deno run -RW scripts/feed.ts
+
+      - name: Commit and push
+        if: github.repository == 'vanilla-os/apx-community' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add _index.json feed.xml
+          git commit -m "chore: new index"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/_index.json
+++ b/_index.json
@@ -1,0 +1,31 @@
+{
+  "stacks": [
+    {
+      "name": "vanilla-golang",
+      "base": "ghcr.io/vanilla-os/pico:main",
+      "packages": [
+        "golang"
+      ],
+      "pkgmanager": "apt",
+      "builtin": false
+    }
+  ],
+  "pkgManagers": [
+    {
+      "name": "apt",
+      "model": 2,
+      "needsudo": true,
+      "cmdautoremove": "apt autoremove",
+      "cmdclean": "apt clean",
+      "cmdinstall": "apt install",
+      "cmdlist": "apt list",
+      "cmdpurge": "apt purge",
+      "cmdremove": "apt remove",
+      "cmdsearch": "apt search",
+      "cmdshow": "apt show",
+      "cmdupdate": "apt update",
+      "cmdupgrade": "apt upgrade",
+      "builtin": false
+    }
+  ]
+}

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Apx Community</title>
+  <subtitle>Live feed of new stacks and package managers from the Apx Community.</subtitle>
+  <link rel="alternate" href="https://apx.vanillaos.org/"/>
+  <updated>2024-10-24T18:33:22.931Z</updated>
+  <generator>Feed for Deno</generator>
+  <author>
+    <name>Vanilla OS Contributors</name>
+    <email>info@vanillaos.org</email>
+  </author>
+  <entry>
+    <title>New Stack: vanilla-golang</title>
+    <link href="https://apx.vanillaos.org/community"/>
+    <id>vanilla-golang</id>
+    <updated>2024-10-24T18:33:22.931Z</updated>
+    <summary>New stack published.</summary>
+    <content type="html">&lt;ul&gt;
+               &lt;li&gt;Base: ghcr.io/vanilla-os/pico:main&lt;/li&gt;
+               &lt;li&gt;Packages: golang&lt;/li&gt;
+               &lt;li&gt;Package Manager: apt&lt;/li&gt;
+               &lt;li&gt;Builtin: No&lt;/li&gt;
+             &lt;/ul&gt;</content>
+  </entry>
+  <entry>
+    <title>New Package Manager: apt</title>
+    <link href="https://apx.vanillaos.org/community"/>
+    <id>apt</id>
+    <updated>2024-10-24T18:33:22.931Z</updated>
+    <summary>New package manager published.</summary>
+    <content type="html">&lt;ul&gt;
+               &lt;li&gt;Model: 2&lt;/li&gt;
+               &lt;li&gt;Needs Sudo: Yes&lt;/li&gt;
+               &lt;li&gt;Command Autoremove: apt autoremove&lt;/li&gt;
+               &lt;li&gt;Command Clean: apt clean&lt;/li&gt;
+               &lt;li&gt;Command Install: apt install&lt;/li&gt;
+               &lt;li&gt;Command List: apt list&lt;/li&gt;
+               &lt;li&gt;Command Purge: apt purge&lt;/li&gt;
+               &lt;li&gt;Command Remove: apt remove&lt;/li&gt;
+               &lt;li&gt;Command Search: apt search&lt;/li&gt;
+               &lt;li&gt;Command Show: apt show&lt;/li&gt;
+               &lt;li&gt;Command Update: apt update&lt;/li&gt;
+               &lt;li&gt;Command Upgrade: apt upgrade&lt;/li&gt;
+               &lt;li&gt;Builtin: No&lt;/li&gt;
+             &lt;/ul&gt;</content>
+  </entry>
+</feed>

--- a/scripts/combine.ts
+++ b/scripts/combine.ts
@@ -1,0 +1,109 @@
+import { walk } from "jsr:@std/fs";
+import { parse } from "jsr:@std/yaml";
+
+interface Stack {
+  name: string;
+  base: string;
+  packages: string[];
+  pkgmanager: string;
+  builtin: boolean;
+}
+
+interface PkgManager {
+  name: string;
+  model: number;
+  needsudo: boolean;
+  cmdautoremove: string;
+  cmdclean: string;
+  cmdinstall: string;
+  cmdlist: string;
+  cmdpurge: string;
+  cmdremove: string;
+  cmdsearch: string;
+  cmdshow: string;
+  cmdupdate: string;
+  cmdupgrade: string;
+  builtin: boolean;
+}
+
+async function parseYamlFile(filePath: string): Promise<unknown> {
+  const fileContent = await Deno.readTextFile(filePath);
+  return parse(fileContent);
+}
+
+async function collectData<T>(
+  dir: string,
+  transform: (data: all) => T,
+): Promise<T[]> {
+  const items: T[] = [];
+
+  for await (
+    const entry of walk(dir, {
+      exts: [".yaml", ".yml"],
+      includeDirs: false,
+    })
+  ) {
+    const data = await parseYamlFile(entry.path);
+    items.push(transform(data));
+  }
+
+  return items;
+}
+
+function collectStacks(stacksDir: string): Promise<Stack[]> {
+  return collectData(stacksDir, (data) => ({
+    name: data.name,
+    base: data.base,
+    packages: data.packages,
+    pkgmanager: data.pkgmanager,
+    builtin: data.builtin,
+  }));
+}
+
+function collectPkgManagers(pkgManagersDir: string): Promise<PkgManager[]> {
+  return collectData(pkgManagersDir, (data) => ({
+    name: data.name,
+    model: data.model,
+    needsudo: data.needsudo,
+    cmdautoremove: data.cmdautoremove,
+    cmdclean: data.cmdclean,
+    cmdinstall: data.cmdinstall,
+    cmdlist: data.cmdlist,
+    cmdpurge: data.cmdpurge,
+    cmdremove: data.cmdremove,
+    cmdsearch: data.cmdsearch,
+    cmdshow: data.cmdshow,
+    cmdupdate: data.cmdupdate,
+    cmdupgrade: data.cmdupgrade,
+    builtin: data.builtin,
+  }));
+}
+
+async function writeToJson(
+  stacks: Stack[],
+  pkgManagers: PkgManager[],
+  outputPath: string,
+) {
+  const data = {
+    stacks,
+    pkgManagers,
+  };
+
+  const jsonString = JSON.stringify(data, null, 2) + "\n";
+  await Deno.writeTextFile(outputPath, jsonString);
+}
+
+async function main() {
+  const stacksDir = "./stacks";
+  const pkgManagersDir = "./pkgmanagers";
+  const outputPath = "./_index.json";
+
+  const stacks = await collectStacks(stacksDir);
+  const pkgManagers = await collectPkgManagers(pkgManagersDir);
+
+  await writeToJson(stacks, pkgManagers, outputPath);
+
+  console.log(`Collected data saved to ${outputPath}`);
+}
+
+main().catch((error) => console.error("Error: ", error));

--- a/scripts/feed.ts
+++ b/scripts/feed.ts
@@ -46,7 +46,7 @@ const feed = new Atom({
   language: "en",
   updated: new Date(),
   feedLinks: {
-    atom: "https://apx-community.vanillaos.org/updates-feed.xml",
+    atom: "https://apx-community.vanillaos.org/feed.xml",
   },
   authors: [
     {

--- a/scripts/feed.ts
+++ b/scripts/feed.ts
@@ -1,0 +1,113 @@
+import { Atom } from "jsr:@feed/feed";
+import { dirname, join } from "jsr:@std/path";
+
+interface Stack {
+  name: string;
+  base: string;
+  packages: string[];
+  pkgmanager: string;
+  builtin: boolean;
+}
+
+interface pkgManager {
+  name: string;
+  model: number;
+  needsudo: boolean;
+  cmdautoremove: string;
+  cmdclean: string;
+  cmdinstall: string;
+  cmdlist: string;
+  cmdpurge: string;
+  cmdremove: string;
+  cmdsearch: string;
+  cmdshow: string;
+  cmdupdate: string;
+  cmdupgrade: string;
+  builtin: boolean;
+}
+
+interface UpdateData {
+  stacks?: Stack[];
+  pkgManagers?: pkgManager[];
+}
+
+const __dirname = dirname(new URL(import.meta.url).pathname);
+
+const data: UpdateData = JSON.parse(
+  await Deno.readTextFile(join(__dirname, "../_index.json")),
+);
+
+const feed = new Atom({
+  title: "Apx Community",
+  description:
+    "Live feed of new stacks and package managers from the Apx Community.",
+  id: "https://apx.vanillaos.org/",
+  link: "https://apx.vanillaos.org/",
+  language: "en",
+  updated: new Date(),
+  feedLinks: {
+    atom: "https://apx-community.vanillaos.org/updates-feed.xml",
+  },
+  authors: [
+    {
+      name: "Vanilla OS Contributors",
+      email: "info@vanillaos.org",
+      link: "https://vanillaos.org/",
+    },
+  ],
+  copyright: "Copyright (c) Vanilla OS Contributors",
+});
+
+const stacks: Stack[] = data.stacks || [];
+const pkgManagers: pkgManager[] = data.pkgManagers || [];
+
+stacks.forEach((stack: Stack) => {
+  feed.addItem({
+    title: `New Stack: ${stack.name}`,
+    id: stack.name,
+    link: "https://apx.vanillaos.org/community",
+    summary: "New stack published.",
+    updated: new Date(),
+    content: {
+      type: "html",
+      body: `<ul>
+               <li>Base: ${stack.base}</li>
+               <li>Packages: ${stack.packages.join(", ")}</li>
+               <li>Package Manager: ${stack.pkgmanager}</li>
+               <li>Builtin: ${stack.builtin ? "Yes" : "No"}</li>
+             </ul>`,
+    },
+  });
+});
+
+pkgManagers.forEach((pkgManager: pkgManager) => {
+  feed.addItem({
+    title: `New Package Manager: ${pkgManager.name}`,
+    id: pkgManager.name,
+    link: "https://apx.vanillaos.org/community",
+    summary: "New package manager published.",
+    updated: new Date(),
+    content: {
+      type: "html",
+      body: `<ul>
+               <li>Model: ${pkgManager.model}</li>
+               <li>Needs Sudo: ${pkgManager.needsudo ? "Yes" : "No"}</li>
+               <li>Command Autoremove: ${pkgManager.cmdautoremove}</li>
+               <li>Command Clean: ${pkgManager.cmdclean}</li>
+               <li>Command Install: ${pkgManager.cmdinstall}</li>
+               <li>Command List: ${pkgManager.cmdlist}</li>
+               <li>Command Purge: ${pkgManager.cmdpurge}</li>
+               <li>Command Remove: ${pkgManager.cmdremove}</li>
+               <li>Command Search: ${pkgManager.cmdsearch}</li>
+               <li>Command Show: ${pkgManager.cmdshow}</li>
+               <li>Command Update: ${pkgManager.cmdupdate}</li>
+               <li>Command Upgrade: ${pkgManager.cmdupgrade}</li>
+               <li>Builtin: ${pkgManager.builtin ? "Yes" : "No"}</li>
+             </ul>`,
+    },
+  });
+});
+
+await Deno.writeTextFile(join(__dirname, "../feed.xml"), feed.build());
+
+console.log("Atom feed generated.");


### PR DESCRIPTION
## Details

- Deno used for both scripts
- The [`@feed/feed`](https://jsr.io/@feed/feed) package is used for the Feed generator
- Only `@std` packages used for the combination screen

