### PR TITLE
feat: add vanilla-node stack

### DIFF
--- a/stacks/vanilla-os/vanilla-node.yml
+++ b/stacks/vanilla-os/vanilla-node.yml
@@ -1,9 +1,9 @@
-# This stack provides a Golang environment for building and running Golang
+# This stack provides a Node.js environment for building and running Node.js
 # applications. It is based on the Vanilla OS Pico image.
 
-name: vanilla-golang
+name: vanilla-node
 base: ghcr.io/vanilla-os/pico:main
 packages:
-  - golang
+  - nodejs
 pkgmanager: apt
 builtin: false


### PR DESCRIPTION
This stack provides a Node.js environment for building and running Node.js applications. It is based on the Vanilla OS Pico image.